### PR TITLE
Improvements to load_billion_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     testthat (>= 3.0.0),
     wppdistro (>= 0.1.0),
     xmart4 (>= 0.2.2),
-    whdh
+    whdh (>= 0.1.0.0000)
 VignetteBuilder: 
     knitr
 Remotes: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: billionaiRe
 Title: Calculate the WHO Triple Billions
-Version: 0.6.5
+Version: 0.6.6
 Authors@R: c(
     person("Seth", "Caldwell", , "caldwellst@gmail.com", role = c("aut", "cre")),
     person("Alice", "Robson", , "robsona@who.int", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# billionaiRe 0.6.6
+* Updates to `load_billion_data` functions incorporating the `whdh::download_data_asset`
+function and the use of a `version` argument to replace the `date_filter` placeholder.
+
 # billionaiRe 0.6.5
 * Adding COVID-19 scenarios.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # billionaiRe 0.6.6
 * Updates to `load_billion_data` functions incorporating the `whdh::download_data_asset`
 function and the use of a `version` argument to replace the `date_filter` placeholder.
+* `load_billion_data` now has an `experiment` argument, which replaces `sandbox`.
 
 # billionaiRe 0.6.5
 * Adding COVID-19 scenarios.

--- a/R/accelerate_uhc.R
+++ b/R/accelerate_uhc.R
@@ -628,7 +628,7 @@ accelerate_dtp3 <- function(df,
     dplyr::filter(.data[[ind]] == this_ind)
 
   df_target_values <- load_misc_data(
-    file_name = "scenarios/dtp3/IA ZD and coverage targets_GPW13.xlsx",
+    file_path = "scenarios/dtp3/IA ZD and coverage targets_GPW13.xlsx",
     skip = 1
   ) %>%
     dplyr::select(!!sym(iso3) := .data[["ISO"]], target = "DTP 3 Target") %>%
@@ -1087,7 +1087,7 @@ accelerate_uhc_tobacco <- function(df,
 
   if (nrow(df_with_data) > 0) {
     trajectory_df <- load_misc_data(
-      file_name = "scenarios/uhc_tobacco/Tobacco_UHC Billion_Trajectory conversion.xlsx",
+      file_path = "scenarios/uhc_tobacco/Tobacco_UHC Billion_Trajectory conversion.xlsx",
       sheet = "Tobacco Data",
       range = cellranger::cell_cols(2:7)
     ) %>%

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -23,19 +23,25 @@
 #' @param ind_codes (character vector) The name of the indicator (or indicators) to load data for.
 #'   If `all`, downloads data for all indicators for a given billion. Ignored if
 #'   billion = "all".
-#' @param version (string) Either "latest", or a single date string. The date
-#'   string needs to be in ISO6801 format, such as "1989-4-4" or "1988-06-21".
-#'   If a date is provided, the returned data frame is a snapshot of the data as
-#'   stored on that date (if no updates were made on the given date, then the most
-#'   recent update before that date is used).
+#' @param version (string) Either `latest`  or a `yyyy-MM-dd` or `yyyy-mm-ddTHH-MM-SS`
+#' formatted string.
+#' * If `latest`, the latest version of the data will be downloaded.
+#' * If a `yyyy-MM-dd` formatted string, the latest version of the data on or
+#' before the provided date will be downloaded.
+#' * If a `yyyy-mm-ddTHH-MM-SS` formatted string, an exact match for the given
+#' time stamp is sought, if it exists; otherwise, raises an error.
 #' @param na_rm (logical) Specifies whether to filter the data to only rows
 #'   where `value` is not missing. Defaults to `TRUE`.
-#' @param experiment (string) Either NULL (default) or a string.
-#' * If NULL, the path returned is in the "official" data layers in the 3B data lake
-#'   (e.g., 3B/Silver).
-#' * If a string, the path returned is in a sub-folder within the Sandbox layer of the
-#'   3B data lake. The Bronze/Silver/Gold structure is replicated within this sub-folder
-#'   (e.g., 3B/Sandbox/my_exp/Silver)
+#' @param experiment (string) Either `NULL` or a string ("unofficial" by default).
+#' Identifies where the Bronze/Silver/Gold data layers from which data is downloaded
+#' are located.
+#' * If `NULL`, the root folder for the data layers is the 3B folder (i.e., where
+#' the "official" data is stored). For example, `3B/Silver/...`.
+#' * If a string, the root folder for the data layers is a sub-folder within the
+#' Sandbox layer of the 3B data lake (e.g., if `experiment = "my_exp"`, then
+#' data is download from `3B/Sandbox/my_exp/{data_layer}/...`)
+#' * If an empty string, the root folder for the data layers is the Sandbox itself
+#'   (i.e., if `experiment = ""`, then data is download from `3B/Sandbox/{data_layer}/...`)
 #' @param silent (logical) Specifies whether to show authentication messages and
 #'   a download progress bar. Defaults to `TRUE`.
 #' @param data_source (string) Ether "whdh" or "xmart". Indicates where to download
@@ -59,6 +65,7 @@ load_billion_data <- function(data_type = c("wrangled_data", "projected_data", "
   data_type <- rlang::arg_match(data_type)
   billion <- rlang::arg_match(billion)
   data_source <- rlang::arg_match(data_source)
+  assert_equals(version, "all", reverse = TRUE)
 
   if (data_source == "whdh") {
     load_billion_data_whdh(data_type, billion, ind_codes, version, na_rm, experiment, silent, ...)

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -23,7 +23,7 @@
 #' @param ind_codes (character vector) The name of the indicator (or indicators) to load data for.
 #'   If `all`, downloads data for all indicators for a given billion. Ignored if
 #'   billion = "all".
-#' @param date_filter (string) Either "latest", or a single date string. The date
+#' @param version (string) Either "latest", or a single date string. The date
 #'   string needs to be in ISO6801 format, such as "1989-4-4" or "1988-06-21".
 #'   If a date is provided, the returned data frame is a snapshot of the data as
 #'   stored on that date (if no updates were made on the given date, then the most

--- a/R/utils_asserts.R
+++ b/R/utils_asserts.R
@@ -183,20 +183,24 @@ assert_arg_exists <- function(x, error_template = "The %s argument is required a
 
 # Object type checks -----------------------------------------------------------
 
-#' Assert that an object is (or is not) of a given type
+#' Assert that an object is (or is not) of a given (range of) type(s)
 #'
 #' @param x The input object
-#' @param expected_type (string) The expected type of x
+#' @param expected (character) The expected type(s) of x
 #' @param reverse Invert the test (i.e., the type of x is not)
-assert_type <- function(x, expected_type, reverse = FALSE) {
-  assert_string(expected_type, 1)
+assert_type <- function(x, expected, reverse = FALSE) {
+  stopifnot(typeof(expected) == "character", typeof(reverse) == "logical")
 
-  cond <- if (reverse) typeof(x) == expected_type else typeof(x) != expected_type
-  msg <- if (reverse) "must not be" else "must be"
-  msg <- paste("%s", msg, "of type %s")
+  cond <- typeof(x) == expected
+  cond <- if (reverse) !any(cond) else any(cond)
 
-  if (!is.null(x) & cond) {
-    stop(sprintf(msg, deparse(substitute(x)), expected_type), call. = FALSE)
+  if (!cond) {
+    msg <- if (reverse) "must **not** be any of" else "must be one of"
+    msg <- sprintf("The type of %s %s {%s}.",
+                   deparse(substitute(x)),
+                   msg,
+                   paste0(expected, collapse = ", "))
+    stop(msg, call. = FALSE)
   }
 }
 

--- a/R/utils_whdh.R
+++ b/R/utils_whdh.R
@@ -185,7 +185,8 @@ get_whdh_path <- function(operation = c("download", "upload"),
   }
 
   path <- paste(root, data_layer, data_type, data_asset, file_names, sep = "/") %>%
-    stringr::str_replace("uhc_espar", "hep_espar")
+    stringr::str_replace("uhc_espar", "hep_espar") %>%
+    stringr::str_replace("//+", "/")
 
   return(path)
 }

--- a/man/assert_type.Rd
+++ b/man/assert_type.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/utils_asserts.R
 \name{assert_type}
 \alias{assert_type}
-\title{Assert that an object is (or is not) of a given type}
+\title{Assert that an object is (or is not) of a given (range of) type(s)}
 \usage{
-assert_type(x, expected_type, reverse = FALSE)
+assert_type(x, expected, reverse = FALSE)
 }
 \arguments{
 \item{x}{The input object}
 
-\item{expected_type}{(string) The expected type of x}
+\item{expected}{(character) The expected type(s) of x}
 
 \item{reverse}{Invert the test (i.e., the type of x is not)}
 }
 \description{
-Assert that an object is (or is not) of a given type
+Assert that an object is (or is not) of a given (range of) type(s)
 }

--- a/man/get_whdh_path.Rd
+++ b/man/get_whdh_path.Rd
@@ -10,7 +10,7 @@ get_whdh_path(
   billion = c("all", "hep", "hpop", "uhc"),
   ind_codes = "all",
   file_names = NULL,
-  sandbox = TRUE
+  experiment = "unofficial"
 )
 }
 \arguments{
@@ -40,7 +40,14 @@ are returned.}
 \item{file_names}{(character vector) The name(s) of the file(s) to download.
 NULL by default. Ignored if either \code{billion = "all"} or \code{ind_codes = "all"}.}
 
-\item{sandbox}{(logical) Whether or not to use the sandbox folders in the data lake.}
+\item{experiment}{(string) Either \code{NULL} or a string ("unofficial" by default).
+\itemize{
+\item If \code{NULL}, the root folder for the data layers is the 3B folder (i.e., where
+the "official" data is stored (e.g., \verb{3B//...}).
+\item If a string, the root folder for the data layers is a sub-folder within the
+Sandbox layer of the 3B data lake (e.g., if \code{experiment = "my_exp"}, then
+paths would be of the form \verb{3B/Sandbox/my_exp/Silver/...})
+}}
 }
 \value{
 A character vector.

--- a/man/load_billion_data.Rd
+++ b/man/load_billion_data.Rd
@@ -10,7 +10,7 @@ load_billion_data(
   ind_codes = "all",
   date_filter = "latest",
   na_rm = TRUE,
-  sandbox = FALSE,
+  experiment = NULL,
   silent = TRUE,
   data_source = c("whdh", "xmart"),
   ...
@@ -43,7 +43,14 @@ recent update before that date is used).}
 \item{na_rm}{(logical) Specifies whether to filter the data to only rows
 where \code{value} is not missing. Defaults to \code{TRUE}.}
 
-\item{sandbox}{(logical) Whether or not to use the sandbox folders in the data lake.}
+\item{experiment}{(string) Either NULL (default) or a string.
+\itemize{
+\item If NULL, the path returned is in the "official" data layers in the 3B data lake
+(e.g., 3B/Silver).
+\item If a string, the path returned is in a sub-folder within the Sandbox layer of the
+3B data lake. The Bronze/Silver/Gold structure is replicated within this sub-folder
+(e.g., 3B/Sandbox/my_exp/Silver)
+}}
 
 \item{silent}{(logical) Specifies whether to show authentication messages and
 a download progress bar. Defaults to \code{TRUE}.}

--- a/man/load_billion_data.Rd
+++ b/man/load_billion_data.Rd
@@ -8,7 +8,7 @@ load_billion_data(
   data_type = c("wrangled_data", "projected_data", "final_data"),
   billion = c("all", "hep", "hpop", "uhc"),
   ind_codes = "all",
-  date_filter = "latest",
+  version = "latest",
   na_rm = TRUE,
   experiment = NULL,
   silent = TRUE,
@@ -34,7 +34,7 @@ downloads all indicators for all three billions.}
 If \code{all}, downloads data for all indicators for a given billion. Ignored if
 billion = "all".}
 
-\item{date_filter}{(string) Either "latest", or a single date string. The date
+\item{version}{(string) Either "latest", or a single date string. The date
 string needs to be in ISO6801 format, such as "1989-4-4" or "1988-06-21".
 If a date is provided, the returned data frame is a snapshot of the data as
 stored on that date (if no updates were made on the given date, then the most

--- a/man/load_billion_data_whdh.Rd
+++ b/man/load_billion_data_whdh.Rd
@@ -8,7 +8,7 @@ load_billion_data_whdh(
   data_type = c("wrangled_data", "projected_data", "final_data"),
   billion = c("all", "hep", "hpop", "uhc"),
   ind_codes = "all",
-  date_filter = "latest",
+  version = "latest",
   na_rm = TRUE,
   experiment = NULL,
   silent = TRUE
@@ -32,7 +32,7 @@ downloads all indicators for all three billions.}
 If \code{all}, downloads data for all indicators for a given billion. Ignored if
 billion = "all".}
 
-\item{date_filter}{(string) Either "latest", or a single date string. The date
+\item{version}{(string) Either "latest", or a single date string. The date
 string needs to be in ISO6801 format, such as "1989-4-4" or "1988-06-21".
 If a date is provided, the returned data frame is a snapshot of the data as
 stored on that date (if no updates were made on the given date, then the most

--- a/man/load_billion_data_whdh.Rd
+++ b/man/load_billion_data_whdh.Rd
@@ -10,7 +10,7 @@ load_billion_data_whdh(
   ind_codes = "all",
   date_filter = "latest",
   na_rm = TRUE,
-  sandbox = FALSE,
+  experiment = NULL,
   silent = TRUE
 )
 }
@@ -41,7 +41,14 @@ recent update before that date is used).}
 \item{na_rm}{(logical) Specifies whether to filter the data to only rows
 where \code{value} is not missing. Defaults to \code{TRUE}.}
 
-\item{sandbox}{(logical) Whether or not to use the sandbox folders in the data lake.}
+\item{experiment}{(string) Either NULL (default) or a string.
+\itemize{
+\item If NULL, the path returned is in the "official" data layers in the 3B data lake
+(e.g., 3B/Silver).
+\item If a string, the path returned is in a sub-folder within the Sandbox layer of the
+3B data lake. The Bronze/Silver/Gold structure is replicated within this sub-folder
+(e.g., 3B/Sandbox/my_exp/Silver)
+}}
 
 \item{silent}{(logical) Specifies whether to show authentication messages and
 a download progress bar. Defaults to \code{TRUE}.}

--- a/man/load_billion_data_xmart.Rd
+++ b/man/load_billion_data_xmart.Rd
@@ -10,7 +10,7 @@ load_billion_data_xmart(
   ind_codes = "all",
   date_filter = "latest",
   na_rm = TRUE,
-  sandbox = FALSE,
+  experiment = NULL,
   silent = TRUE
 )
 }
@@ -41,7 +41,14 @@ recent update before that date is used).}
 \item{na_rm}{(logical) Specifies whether to filter the data to only rows
 where \code{value} is not missing. Defaults to \code{TRUE}.}
 
-\item{sandbox}{(logical) Whether or not to use the sandbox folders in the data lake.}
+\item{experiment}{(string) Either NULL (default) or a string.
+\itemize{
+\item If NULL, the path returned is in the "official" data layers in the 3B data lake
+(e.g., 3B/Silver).
+\item If a string, the path returned is in a sub-folder within the Sandbox layer of the
+3B data lake. The Bronze/Silver/Gold structure is replicated within this sub-folder
+(e.g., 3B/Sandbox/my_exp/Silver)
+}}
 
 \item{silent}{(logical) Specifies whether to show authentication messages and
 a download progress bar. Defaults to \code{TRUE}.}

--- a/man/load_billion_data_xmart.Rd
+++ b/man/load_billion_data_xmart.Rd
@@ -8,7 +8,7 @@ load_billion_data_xmart(
   data_type = c("wrangled_data", "projected_data", "final_data"),
   billion = c("all", "hep", "hpop", "uhc"),
   ind_codes = "all",
-  date_filter = "latest",
+  version = "latest",
   na_rm = TRUE,
   experiment = NULL,
   silent = TRUE
@@ -32,7 +32,7 @@ downloads all indicators for all three billions.}
 If \code{all}, downloads data for all indicators for a given billion. Ignored if
 billion = "all".}
 
-\item{date_filter}{(string) Either "latest", or a single date string. The date
+\item{version}{(string) Either "latest", or a single date string. The date
 string needs to be in ISO6801 format, such as "1989-4-4" or "1988-06-21".
 If a date is provided, the returned data frame is a snapshot of the data as
 stored on that date (if no updates were made on the given date, then the most

--- a/man/load_misc_data.Rd
+++ b/man/load_misc_data.Rd
@@ -4,31 +4,22 @@
 \alias{load_misc_data}
 \title{Load miscellaneous data}
 \usage{
-load_misc_data(file_name, ...)
-
-load_misc_data(file_name, ...)
+load_misc_data(file_path, ...)
 }
 \arguments{
-\item{file_name}{The name of the file. File names must end with an extension (e.g., .csv)}
+\item{file_path}{The path to the file inside the \verb{3B/Bronze/misc} folder. File
+paths must end with an extension (e.g., .csv)}
 
 \item{...}{Any additionally arguments to pass on to the appropriate \code{read_} function.}
 }
 \value{
-data frame
-
 a data frame
 }
 \description{
 This function fetches and read data stored in the 3B/Bronze/misc/ folder in the
 WHDH data lake.
-
-This function fetches and read data stored in the 3B/Bronze/misc/ folder in the
-WHDH data lake.
 }
 \details{
-It automatically selects between \code{readr::read_csv()}, \code{arrow::read_parquet()},
-and \code{readxl::read_excel()} based on the file extension.
-
 It automatically selects between \code{readr::read_csv()}, \code{arrow::read_parquet()},
 and \code{readxl::read_excel()} based on the file extension.
 }

--- a/tests/testthat/test_accelerate_hep.R
+++ b/tests/testthat/test_accelerate_hep.R
@@ -98,7 +98,7 @@ basic_hep_test <- function(ind) {
 purrr::walk(c("respond", "notify", "detect", "detect_respond"), basic_hep_test)
 
 testthat::test_that("accelerate_cholera_campaign returns accurate results:", {
-  hep_test_df <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  hep_test_df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "hep") %>%
     dplyr::filter(ind %in% billion_ind_codes("hep")[stringr::str_detect(billion_ind_codes("hep"), "cholera_campaign")])
 
@@ -158,7 +158,7 @@ testthat::test_that("accelerate_measles_routine returns accurate results:", {
 })
 
 testthat::test_that("accelerate_meningitis_campaign returns accurate results:", {
-  hep_test_df <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  hep_test_df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "hep") %>%
     dplyr::filter(ind %in% billion_ind_codes("hep")[stringr::str_detect(billion_ind_codes("hep"), "meningitis_campaign")])
 
@@ -197,7 +197,7 @@ testthat::test_that("accelerate_meningitis_routine returns accurate results:", {
 
   testthat::expect_equal(df_add_scenario_2025, fixed_target_2025)
 
-  test_data <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  test_data <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "hep")
 
   df_add_scenario_indicator <- add_scenario_indicator(test_data, "accelerate", "meningitis_routine")
@@ -308,7 +308,7 @@ testthat::test_that("accelerate_yellow_fever_routine returns accurate results:",
 })
 
 testthat::test_that("accelerate can be run on all hep indicators:", {
-  hep_test_df <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  hep_test_df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "hep") %>%
     dplyr::filter(ind %in% billion_ind_codes("hep") &
       !.data[["ind"]] %in% billion_ind_codes("hep")[stringr::str_detect(billion_ind_codes("hep"), "espar")])

--- a/tests/testthat/test_accelerate_hpop.R
+++ b/tests/testthat/test_accelerate_hpop.R
@@ -497,7 +497,7 @@ testthat::test_that("accelerate can be run on all hpop indicators:", {
   testthat::expect_equal(nrow(calculated_test_data), 609)
 
   testthat::expect_error(
-    load_misc_data("test_data/test_data/test_data.parquet") %>%
+    load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
       dplyr::filter(ind %in% billion_ind_codes("hpop")) %>%
       make_default_scenario(billion = "uhc") %>%
       add_scenario("accelerate"),

--- a/tests/testthat/test_accelerate_uhc.R
+++ b/tests/testthat/test_accelerate_uhc.R
@@ -263,7 +263,7 @@ testthat::test_that(paste0("accelerate_uhc_tobacco returns accurate values:"), {
 })
 
 testthat::test_that("accelerate can be run on all UHC indicator:", {
-  uhc_test_df <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  uhc_test_df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "uhc") %>%
     dplyr::filter(
       ind %in% billion_ind_codes("uhc"),

--- a/tests/testthat/test_consistent_billion_results.R
+++ b/tests/testthat/test_consistent_billion_results.R
@@ -44,9 +44,9 @@ testthat::test_that("basic billion calculations are consistent", {
   testthat::expect_equal(all_basic_calculated, billionaiRe:::basic_test_calculated)
 })
 
-test_data <- load_misc_data("test_data/test_data/test_data.parquet")
+test_data <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet")
 
-test_data_calculated <- load_misc_data("test_data/test_data_calculated/test_data_calculated.parquet")
+test_data_calculated <- load_misc_data("test_data/test_data_calculated/test_data_calculated_2022-01-20T14-12-38.parquet")
 
 
 testthat::test_that("HEP complexe billion calculations without scenarios are consistent", {

--- a/tests/testthat/test_data_recycling.R
+++ b/tests/testthat/test_data_recycling.R
@@ -1,6 +1,6 @@
-test_data <- load_misc_data("test_data/test_data/test_data.parquet")
+test_data <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet")
 
-test_data_calculated <- load_misc_data("test_data/test_data_calculated/test_data_calculated.parquet")
+test_data_calculated <- load_misc_data("test_data/test_data_calculated/test_data_calculated_2022-01-20T14-12-38.parquet")
 
 testthat::test_that("HEP data recycling returns right number of rows", {
   test_data_calculated_hep <- test_data_calculated %>%

--- a/tests/testthat/test_load_data.R
+++ b/tests/testthat/test_load_data.R
@@ -111,3 +111,10 @@ testthat::test_that("WHDH: load_billion_data correctly handles na_rm", {
   # testthat::expect_true(nrow(df_na) > 0)
   # testthat::expect_true(nrow(df_no_na) == 0)
 })
+
+# load_misc_data ---------------------------------
+
+testthat::test_that("load_misc_data works as expected", {
+  testthat::expect_equal(105, nrow(load_misc_data("pulse/pulse.csv")))
+  testthat::expect_equal(106, nrow(load_misc_data("pulse/pulse.csv", col_names = FALSE)))
+})

--- a/tests/testthat/test_sdg_hpop.R
+++ b/tests/testthat/test_sdg_hpop.R
@@ -488,7 +488,7 @@ testthat::test_that("sdg can be run on all hpop indicators:", {
   testthat::expect_equal(nrow(calculated_test_data), 609)
 
   testthat::expect_error(
-    load_misc_data("test_data/test_data/test_data.parquet") %>%
+    load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
       dplyr::filter(ind %in% billion_ind_codes("hpop")) %>%
       make_default_scenario(billion = "uhc") %>%
       add_scenario("sdg"),

--- a/tests/testthat/test_sdg_uhc.R
+++ b/tests/testthat/test_sdg_uhc.R
@@ -255,7 +255,7 @@ testthat::test_that(paste0("sdg_uhc_tobacco returns accurate values:"), {
 })
 
 testthat::test_that("sdg can be run on all UHC indicator:", {
-  uhc_test_df <- load_misc_data("test_data/test_data/test_data.parquet") %>%
+  uhc_test_df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>%
     make_default_scenario(billion = "uhc") %>%
     dplyr::filter(
       ind %in% billion_ind_codes("uhc"),

--- a/tests/testthat/test_target_specific_values.R
+++ b/tests/testthat/test_target_specific_values.R
@@ -1,4 +1,4 @@
-test_data <- load_misc_data("test_data/test_data/test_data.parquet")
+test_data <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet")
 
 testthat::test_that("scenarios_quantile produces accurate results:", {
   test_data_quantile <- test_data %>%

--- a/tests/testthat/test_utils_asserts.R
+++ b/tests/testthat/test_utils_asserts.R
@@ -11,3 +11,16 @@ testthat::test_that("assert_equals works as expected", {
   testthat::expect_error(assert_equals(1, 1.0, iden = F, rev = T), "must not be equal")
   testthat::expect_error(assert_equals(1, 1.0, iden = T, rev = T), "must not be identical")
 })
+
+# assert_type -----------------------------
+
+testthat::test_that("assert_type works as expected", {
+  T <- TRUE
+  F <- FALSE
+  testthat::expect_error(assert_type("hello", "logical"))
+  testthat::expect_error(assert_type("hello", "character", T))
+  testthat::expect_error(assert_type("hello", c("logical", "double", "integer")))
+  testthat::expect_error(assert_type("hello", c("character", "double", "integer"), T))
+  testthat::expect_error(assert_type(NULL, "character"))
+  testthat::expect_error(assert_type(NULL, c("NULL", "logical"), T))
+})

--- a/tests/testthat/test_utils_whdh.R
+++ b/tests/testthat/test_utils_whdh.R
@@ -4,14 +4,14 @@
 test_that("WHDH download path with no file_names is a directory", {
   expect_equal(
     get_whdh_path("download", "wrangled_data", "hpop", "alcohol"),
-    "3B/Sandbox/Silver/wrangled_data/hpop_alcohol/"
+    "3B/Sandbox/unofficial/Silver/wrangled_data/hpop_alcohol/"
   )
 })
 
 test_that("WHDH download path with file_names is a file", {
   expect_equal(
     get_whdh_path("download", "ingestion_data", "hpop", "alcohol", "AC Data 2020.xlsx"),
-    "3B/Sandbox/Bronze/ingestion_data/hpop_alcohol/AC Data 2020.xlsx"
+    "3B/Sandbox/unofficial/Bronze/ingestion_data/hpop_alcohol/AC Data 2020.xlsx"
   )
 })
 
@@ -36,27 +36,27 @@ test_that("WHDH: File names with no extensions raise error", {
 test_that("final_data download paths are generated correctly", {
   expect_equal(
     suppressMessages(get_whdh_path("download", "final_data", "hpop", "alcohol", "hats.xlsx")),
-    "3B/Sandbox/Gold/final_data/final_data/hats.xlsx"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/hats.xlsx"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("download", "final_data", "hpop", "alcohol")),
-    "3B/Sandbox/Gold/final_data/final_data/"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("download", "final_data", "all", "all")),
-    "3B/Sandbox/Gold/final_data/final_data/"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("download", "final_data")),
-    "3B/Sandbox/Gold/final_data/final_data/"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("download", "final_data", file_names = "cars.csv")),
-    "3B/Sandbox/Gold/final_data/final_data/cars.csv"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/cars.csv"
   )
 })
 
@@ -98,24 +98,24 @@ test_that("Upload paths require file_names", {
 test_that("Correct upload path is returned", {
   expect_equal(
     get_whdh_path("upload", "wrangled_data", "uhc", "uhc_tobacco", "uhc_uhc_tobacco_2021-10-12T18-32-44.parquet"),
-    "3B/Sandbox/Silver/wrangled_data/uhc_uhc_tobacco/uhc_uhc_tobacco_2021-10-12T18-32-44.parquet"
+    "3B/Sandbox/unofficial/Silver/wrangled_data/uhc_uhc_tobacco/uhc_uhc_tobacco_2021-10-12T18-32-44.parquet"
   )
 })
 
 test_that("final_data upload paths are generated correctly", {
   expect_equal(
     suppressMessages(get_whdh_path("upload", "final_data", "hpop", "alcohol", "cars.csv")),
-    "3B/Sandbox/Gold/final_data/final_data/cars.csv"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/cars.csv"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("upload", "final_data", "all", "all", "cars.csv")),
-    "3B/Sandbox/Gold/final_data/final_data/cars.csv"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/cars.csv"
   )
 
   expect_equal(
     suppressMessages(get_whdh_path("upload", "final_data", file_names = "cars.csv")),
-    "3B/Sandbox/Gold/final_data/final_data/cars.csv"
+    "3B/Sandbox/unofficial/Gold/final_data/final_data/cars.csv"
   )
 })
 
@@ -126,14 +126,14 @@ test_that("final_data upload paths raise billion and ind_code arguments ignored 
   )
 })
 
-test_that("get_whdh_path: sandbox argument is respected", {
+test_that("get_whdh_path: experiment argument is respected", {
   expect_equal(
-    get_whdh_path("download", "wrangled_data", "hpop", "alcohol", sandbox = TRUE),
-    "3B/Sandbox/Silver/wrangled_data/hpop_alcohol/"
+    get_whdh_path("download", "wrangled_data", "hpop", "alcohol", experiment = "dnr_exp"),
+    "3B/Sandbox/dnr_exp/Silver/wrangled_data/hpop_alcohol/"
   )
 
   expect_equal(
-    get_whdh_path("download", "wrangled_data", "hpop", "alcohol", sandbox = FALSE),
+    get_whdh_path("download", "wrangled_data", "hpop", "alcohol", experiment = NULL),
     "3B/Silver/wrangled_data/hpop_alcohol/"
   )
 })
@@ -142,19 +142,19 @@ test_that("get_whdh_path: vector arguments are handled correctly", {
   # Vectorised ind_codes
   expect_equal(
     get_whdh_path("download", "wrangled_data", "hpop", c("alcohol", "hpop_sanitation")),
-    c("3B/Sandbox/Silver/wrangled_data/hpop_alcohol/", "3B/Sandbox/Silver/wrangled_data/hpop_hpop_sanitation/")
+    c("3B/Sandbox/unofficial/Silver/wrangled_data/hpop_alcohol/", "3B/Sandbox/unofficial/Silver/wrangled_data/hpop_hpop_sanitation/")
   )
 
   # Vectorised files_names
   expect_equal(
     get_whdh_path("download", "wrangled_data", "hpop", "alcohol", c("cars.csv", "stars.parquet")),
-    c("3B/Sandbox/Silver/wrangled_data/hpop_alcohol/cars.csv", "3B/Sandbox/Silver/wrangled_data/hpop_alcohol/stars.parquet")
+    c("3B/Sandbox/unofficial/Silver/wrangled_data/hpop_alcohol/cars.csv", "3B/Sandbox/unofficial/Silver/wrangled_data/hpop_alcohol/stars.parquet")
   )
 
   # Vectorised ind_codes and file_names with 1-to-1 matching
   expect_equal(
     get_whdh_path("download", "wrangled_data", "hpop", c("alcohol", "pm25"), c("cars.csv", "stars.parquet")),
-    c("3B/Sandbox/Silver/wrangled_data/hpop_alcohol/cars.csv", "3B/Sandbox/Silver/wrangled_data/hpop_pm25/stars.parquet")
+    c("3B/Sandbox/unofficial/Silver/wrangled_data/hpop_alcohol/cars.csv", "3B/Sandbox/unofficial/Silver/wrangled_data/hpop_pm25/stars.parquet")
   )
 
   # Vectorised ind_codes and files_names without 1-to-1 matching returns an error

--- a/vignettes/scenarios.Rmd
+++ b/vignettes/scenarios.Rmd
@@ -49,7 +49,7 @@ Data recycling works by adding to all scenarios present in the `scenario` column
 ```{r, include = TRUE, eval = TRUE}
 library(billionaiRe)
 
-df <- load_misc_data("test_data/test_data/test_data.parquet")
+df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet")
 
 scenario_df <- df %>%
   dplyr::filter(scenario == "covid_dip_lag")
@@ -105,7 +105,7 @@ detect_respond_afg_2018 <- data.frame(
   scenario = "none",
   type = "estimated")
 
-df <- load_misc_data("test_data/test_data/test_data.parquet") %>% 
+df <- load_misc_data("test_data/test_data/test_data_2022-01-20T14-13-10.parquet") %>% 
   dplyr::bind_rows(detect_respond_afg_2018)
 
 test_data_hep <- df %>%


### PR DESCRIPTION
This PR updates the various functions relating to WHDH downloads to be compatible with the latest changes to the `whdh` package.

* It updates `load_billion_data` to work with the `whdh::downlaod_data_asset` function and ;
* allows the user to specify a version of the data_asset to be downloaded. (The `date_filter` argument, which the new `version` argument replaces, was previously just a placeholder and non-functional.)