### PR TITLE
Deprecate `dropzone`

### DIFF
--- a/R/upload_data.R
+++ b/R/upload_data.R
@@ -93,7 +93,7 @@ upload_billion_data <- function(df,
     retry::retry({
       whdh::upload_to_data_lake(
         data_lake_name = get_data_lake_name(),
-        container = "dropzone",
+        container = "whdh",
         source_path = output_file,
         destination_path = upload_path,
         silent = FALSE
@@ -105,7 +105,7 @@ upload_billion_data <- function(df,
   } else {
     whdh::upload_to_data_lake(
       data_lake_name = get_data_lake_name(),
-      container = "dropzone",
+      container = "whdh",
       source_path = output_file,
       destination_path = upload_path,
       silent = FALSE

--- a/R/utils_whdh.R
+++ b/R/utils_whdh.R
@@ -41,7 +41,7 @@ save_gho_backup_to_whdh <- function(df,
   # Upload the parquet file to the data lake
   whdh::upload_to_data_lake(
     data_lake_name = get_data_lake_name(),
-    container = "dropzone",
+    container = "whdh",
     source_path = temp_file,
     destination_path = gho_backup_path,
     validate_user_input = FALSE,

--- a/data-raw/billions_examples.R
+++ b/data-raw/billions_examples.R
@@ -175,14 +175,14 @@ arrow::write_parquet(test_data, test_data_output_path)
 
 whdh::upload_to_data_lake(
   data_lake_name = get_data_lake_name(),
-  container = "dropzone",
+  container = "whdh",
   source_path = test_data_output_path,
   destination_path = test_data_destination_path_notimestamp
 )
 
 whdh::upload_to_data_lake(
   data_lake_name = get_data_lake_name(),
-  container = "dropzone",
+  container = "whdh",
   source_path = test_data_output_path,
   destination_path = test_data_destination_path
 )
@@ -199,14 +199,14 @@ arrow::write_parquet(test_data_calculated, test_data_calculated_output_path)
 
 whdh::upload_to_data_lake(
   data_lake_name = get_data_lake_name(),
-  container = "dropzone",
+  container = "whdh",
   source_path = test_data_calculated_output_path,
   destination_path = test_data_calculated_destination_path
 )
 
 whdh::upload_to_data_lake(
   data_lake_name = get_data_lake_name(),
-  container = "dropzone",
+  container = "whdh",
   source_path = test_data_calculated_output_path,
   destination_path = test_data_destination_path_notimestamp
 )
@@ -227,7 +227,7 @@ test_data_unofficial_destination_path <- glue::glue("3B/Bronze/misc_data/test_da
 whdh::upload_to_data_lake(
   data_lake_name = get_data_lake_name(),
   source_path = test_data_output_path,
-  container = "dropzone",
+  container = "whdh",
   destination_path = test_data_unofficial_destination_path
 )
 


### PR DESCRIPTION
The WHDH team has removed the `dropzone` from the datalake product. Read/write directly from `whdh` container now.